### PR TITLE
Fixed path in pip install command

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -42,6 +42,6 @@ echo -e '\n'
 echo '########################################################################'
 echo '[*] Installing python requirements...'
 echo '########################################################################'
-pip3 install -r ~/PrimusC2/requirements.txt
+pip3 install -r requirements.txt
 
 


### PR DESCRIPTION
Hello 👋🏻 
I have addressed the issue where the setup script assumed requirements.txt was in the user's home directory. This should prevent failures when installing dependencies.